### PR TITLE
Fix | AudioUrl Timeout Bug

### DIFF
--- a/app/models/phrase.rb
+++ b/app/models/phrase.rb
@@ -18,7 +18,7 @@ class Phrase < ApplicationRecord
   def audio_url
     if audio.attached?
       if Rails.env.production?
-        audio.url
+        audio.url(expires_in: 3.hours)
       else
         Rails.application.routes.url_helpers.rails_blob_url(audio, only_path: false)
       end


### PR DESCRIPTION
## What this PR does

- Fixes a bug that results in Audio not playing if the phrase is clicked after 5 minutes.
- Increase the expiry for audio_url in production to 3 hours.

## Cause

Default expiry was 5 minutes, meaning that all urls to fetch relevant audio files would fail to load if they weren't clicked within the initial 5 minute period.

## Console

Note that the expiry is in seconds.

```ruby
Phrase.first.audio.url(expires_in: 3.hours)
=> ... Amz-Expires=10800&X-Amz-SignedHeaders=...
```

```ruby
Phrase.first.audio.url
...Amz-Expires=300&X-Amz-SignedHeaders=...
```
