### PR TITLE
Fix |  join_codes_controller.rb

### DIFF
--- a/app/controllers/account/join_codes_controller.rb
+++ b/app/controllers/account/join_codes_controller.rb
@@ -1,4 +1,4 @@
-class Accounts::JoinCodesController < ApplicationController
+class Account::JoinCodesController < ApplicationController
   before_action :authenticate_user!
 
   def create


### PR DESCRIPTION
Fixes a typo, `Accounts` / `Account`